### PR TITLE
accept tcp/udp syslog events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ EXPOSE 514/tcp 514/udp
 
 ADD scripts/* /root/
 ADD files/* /root/files/
+COPY rsyslog.conf /etc/rsyslog.conf
 
 ENTRYPOINT /root/go.bash

--- a/files/json-file.conf
+++ b/files/json-file.conf
@@ -7,7 +7,8 @@ global(workDirectory="LOGZ_SPOOL_DIR")
 
 $PrivDropToGroup adm
 
-# Load Modules
+### Load Modules
+# File Module
 module(load="imfile")
 
 # rsyslog Templates
@@ -24,11 +25,9 @@ input(type="imfile"
 
 # rsyslog RuleSets
 ruleset(name="FILE_TAG_roleset") {
-    if $programname == "FILE_TAG" then {
         action(type="omfwd" 
             Target="LISTENER_HOST"
             Port="LISTENER_PORT"
             Protocol="LISTENER_PROTOCOL"
             template="jsonline")
-    }
 }

--- a/files/text-file.conf
+++ b/files/text-file.conf
@@ -7,7 +7,8 @@ global(workDirectory="LOGZ_SPOOL_DIR")
 
 $PrivDropToGroup adm
 
-# Load Modules
+### Load Modules
+# File Module
 module(load="imfile")
 
 # rsyslog Templates
@@ -24,12 +25,10 @@ input(type="imfile"
 
 # rsyslog RuleSets
 ruleset(name="FILE_TAG_roleset") {
-    if $programname == "FILE_TAG" then {
         action(type="omfwd"
             Target="LISTENER_HOST"
             Port="LISTENER_PORT"
             Protocol="LISTENER_PROTOCOL"
             template="logline")
-    }
 }
 

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,0 +1,96 @@
+# rsyslog v5: load input modules
+# If you do not load inputs, nothing happens!
+# You may need to set the module load path if modules are not found.
+
+$ModLoad immark.so # provides --MARK-- message capability
+$ModLoad imuxsock.so # provides support for local system logging (e.g. via logger command)
+$ModLoad imklog.so # kernel logging (formerly provided by rklogd)
+
+# default permissions for all log files.
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+# Include configuration files from directory
+$IncludeConfig /etc/rsyslog.d/*
+
+# Check config syntax on startup and abort if unclean (default off)
+#$AbortOnUncleanConfig on
+
+# Reduce repeating messages (default off)
+#$RepeatedMsgReduction on
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                -/var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+# Log cron stuff
+cron.*                                                  -/var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          -/var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+# More configuration examples:
+#
+# Remote Logging (we use TCP for reliable delivery)
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$WorkDirectory /var/spool/rsyslog # where to place spool files
+#$ActionQueueFileName uniqName # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinety retries if host is down
+#$ActionResumeInterval 30      # retry interval
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host
+
+# Remote Logging with TCP + SSL/TLS
+#$DefaultNetstreamDriver gtls
+#$DefaultNetstreamDriverCAFile /etc/ssl/rsyslog/rsyslog_ca.cert.pem
+#$DefaultNetstreamDriverCertFile /etc/ssl/rsyslog/rsyslog_CLIENT.cert.pem
+#$DefaultNetstreamDriverKeyFile /etc/ssl/rsyslog/rsyslog_CLIENT.key.pem
+#$ActionSendStreamDriverAuthMode x509/name # enable peer authentication
+#$ActionSendStreamDriverPermittedPeer foo # authorize to send encrypted data to server foo
+#$ActionSendStreamDriverMode 1 # run driver in TLS-only mode
+
+# ######### Receiving Messages from Remote Hosts ##########
+# TCP Syslog Server:
+$ModLoad imtcp # needs to be done just once
+$InputTCPMaxSessions 500
+$InputTCPServerBindRuleset text_roleset
+$InputTCPServerRun 1514
+
+# TCP + SSL/TLS Syslog Server:
+#$ModLoad imtcp  # provides TCP syslog reception
+#$DefaultNetstreamDriver gtls # use gnuTLS for data encryption
+#$DefaultNetstreamDriverCAFile /etc/ssl/rsyslog/rsyslog_ca.cert.pem
+#$DefaultNetstreamDriverCertFile /etc/ssl/rsyslog/rsyslog_SERVER.cert.pem
+#$DefaultNetstreamDriverKeyFile /etc/ssl/rsyslog/rsyslog_SERVER.key.pem
+#$InputTCPServerStreamDriverMode 1 # run driver in TLS-only mode
+#$InputTCPServerStreamDriverAuthMode x509/name # enable peer authentication
+#$InputTCPServerStreamDriverPermittedPeer bar # authorize client named bar (one line per client)
+#$TCPServerRun 10514 # start a TCP syslog server at port 10514
+
+# UDP Syslog Server:
+$ModLoad imudp.so  # provides UDP syslog reception
+$InputUDPServerBindRuleset text_roleset
+$UDPServerRun 1514 # start a UDP syslog server at standard port 514


### PR DESCRIPTION
Updated ruleset to remove condition on $programname and added tcp / udp input modules and config so the image can be used to receive events over the network instead of just mounting in a docker volume with logs. 