### PR TITLE
Allow customization of the shared directory used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The following environment variables are available:
 	The path can be to a single file or directory. wildcards are allowed only on the file name. 
 	for more details please see Rsyslog documentation 
 
+**SHARED_DIR**
+
+    The path to use as the shared directory for logzio. This must be a **absolute** path.
+    This path has the **MONITOR_FILE_PATH** variable appended to it when searching for logs.
+    By default, this is `/var/log/logzio`.
+
 **CODEC**
 
 	The file content codec, currntly support text and json, Default to text.
@@ -86,7 +92,7 @@ docker run \
 
 
 
-This example monitor the myapp log files, The path to the files is **relative to the mounted folder**. 
+This example monitor the myapp log files, The path to the files is **relative to the SHARED_DIR variable.**
 
 All file are assumed to be a json log files.
 
@@ -99,6 +105,22 @@ docker run \
 	-e LISTENER_HOST="listener-eu.logz.io" \
 	-e MONITOR_FILE_PATH="logs/*.json" \
 	-e MONITOR_FILE_TYPE="myapp" \
+	-e CODEC="json" \
+	logzio/logzio-rsyslog-shipper:latest
+```
+
+All files are within a different shared folder.
+
+``` bash
+docker run \
+	-d \
+	--name rsyslog-shipper \
+	-v /home/ubuntu/myapp:/var/log/mylogs \
+	-e LOGZIO_USER_TOKEN="USER_TOKEN" \
+	-e LISTENER_HOST="listener-eu.logz.io" \
+	-e MONITOR_FILE_PATH="logs/*.json" \
+	-e MONITOR_FILE_TYPE="myapp" \
+    -e SHARED_DIR="/var/log/mylogs" \
 	-e CODEC="json" \
 	logzio/logzio-rsyslog-shipper:latest
 ```

--- a/scripts/configure_rsyslog.bash
+++ b/scripts/configure_rsyslog.bash
@@ -14,27 +14,31 @@ RSYSLOG_CONF_DIR="/etc/rsyslog.d"
 # Logzio conf's directory path
 LOGZ_CONF_DIR="/root/files"
 
-# Logzio - shared directory
-LOGZ_SHARED_DIR="/var/log/logzio"
-
 # the user's authentication token, this is a mandatory input
 USER_TOKEN=${1}
+
+# Logzio - shared directory
+LOGZ_SHARED_DIR=${2}
+
+if [[ $LOGZ_SHARED_DIR == "" ]]; then
+    LOGZ_SHARED_DIR="/var/log/logzio"
+fi
 
 # The log file path
 FILE_PATH=${LOGZ_SHARED_DIR}
 
-if [[ ! -z "${2}" ]]; then
-	FILE_PATH=${LOGZ_SHARED_DIR}/${2}
+if [[ ! -z "${3}" ]]; then
+	FILE_PATH=${LOGZ_SHARED_DIR}/${3}
 fi
 
 # The log file type
-FILE_TAG=${3}
+FILE_TAG=${4}
 
 # The log file content
-FILE_CONTENT=${4}
+FILE_CONTENT=${5}
 
 # Configure listener protocol
-LISTENER_PROTOCOL=${5}
+LISTENER_PROTOCOL=${6}
 
 # Logzio - spool directory
 LOGZ_SPOOL_DIR="${LOGZ_SHARED_DIR}/spool/rsyslog"

--- a/scripts/go.bash
+++ b/scripts/go.bash
@@ -21,7 +21,7 @@ if [[ $MONITOR_FILE_TYPE == "" ]]; then
 fi
 
 # configure rsyslog && start service in background
-/root/configure_rsyslog.bash "${LOGZIO_USER_TOKEN}" "${MONITOR_FILE_PATH}" "${MONITOR_FILE_TYPE}" "${CODEC}" 
+/root/configure_rsyslog.bash "${LOGZIO_USER_TOKEN}" "${SHARED_DIR}" "${MONITOR_FILE_PATH}" "${MONITOR_FILE_TYPE}" "${CODEC}" 
 
 #if [[ $MONITOR_CONF_FILE_PATH == "" ]]; then
 #	# configure rsyslog && start service in background
@@ -44,4 +44,3 @@ done
 
 # stop service
 cleanup
-


### PR DESCRIPTION
By default, this docker image uses the `/var/log/logzio` directory the assumed mounted directory.

When using a system such as nomad to run docker containers this is not ideal as all logs are generally within the allocations shared mounts (`/alloc/logs` for example).

This change makes it so that you can set a `SHARED_DIR` variable to point to another directory of your choice instead of the `/var/log/logzio` directory.

By default, all functionality is the same as before and there should be no breaking changes introduced.

You can find a built docker image running this change here: https://hub.docker.com/r/pmconnect/logzio-rsyslog-shipper/